### PR TITLE
fix: remove deprecated pylint option and refactor constants

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -99,10 +99,6 @@ recursive=no
 # source root.
 source-roots=
 
-# When enabled, pylint would attempt to guess common misconfiguration and emit
-# user-friendly hints instead of false-positive error messages.
-suggestion-mode=yes
-
 # Allow loading of arbitrary C extensions. Extensions are imported into the
 # active Python interpreter and may run arbitrary code.
 unsafe-load-any-extension=no

--- a/yf_stock_ticker/yf_stock_ticker.py
+++ b/yf_stock_ticker/yf_stock_ticker.py
@@ -10,14 +10,14 @@ import requests.exceptions
 from yahooquery import Ticker
 
 
-SYMBOLS_TICKER = []
-SYMBOLS_DROPDOWN = []
 # user defined list of stock to display (in the navbar or in the dropdown)
 # space delimited environment variables are converted to list (removing empty elements)
-if os.environ.get('VAR_TICKER_SYMBOLS') is not None:
-    SYMBOLS_TICKER = list(filter(None, os.environ.get('VAR_TICKER_SYMBOLS').split(' ')))
-if os.environ.get('VAR_DROPDOWN_SYMBOLS') is not None:
-    SYMBOLS_DROPDOWN = list(filter(None, os.environ.get('VAR_DROPDOWN_SYMBOLS').split(' ')))
+SYMBOLS_TICKER = (
+    list(filter(None, os.environ.get('VAR_TICKER_SYMBOLS', '').split(' ')))
+)
+SYMBOLS_DROPDOWN = (
+    list(filter(None, os.environ.get('VAR_DROPDOWN_SYMBOLS', '').split(' ')))
+)
 
 
 # Enable debug


### PR DESCRIPTION
- Remove obsolete suggestion-mode option from pylintrc
- Refactor SYMBOLS_TICKER and SYMBOLS_DROPDOWN to single assignments to satisfy pylint constant naming convention