### PR TITLE
feat: add pre-market and after-hours price changes to dropdown

### DIFF
--- a/tests/test_yf_stock_ticker.py
+++ b/tests/test_yf_stock_ticker.py
@@ -69,6 +69,7 @@ def test_gen_drodpdown(capsys):
 """AAPL        174.79     +0.49% 🌘 | font='Menlo'
 --Apple Inc. (USD) | font='Menlo'
 --Previous Close: 173.93 | font='Menlo'
+--After-hours:    +0.09% (+0.16) | font='Menlo'
 --Open:           174.67 | font='Menlo'
 --Day's Range:    174.06 - 177.08 | font='Menlo'
 """

--- a/yf_stock_ticker/yf_stock_ticker.py
+++ b/yf_stock_ticker/yf_stock_ticker.py
@@ -47,6 +47,7 @@ def get_quotes(symbols):
             if not isinstance(data[symbol], dict):
                 log.warning("Quote not found for symbol: %s", symbol)
                 del data[symbol]
+
     return data
 
 
@@ -105,10 +106,26 @@ def gen_dropdown(symbol_data):
     output += f"{symbol:<7} {regular_market_price:>10} {formated_change:>10} {suffix}" + FONT + "\n"
     output += f"--{symbol_data['longName']} ({symbol_data['currency']})" + FONT + "\n"
     output += f"--Previous Close: {symbol_data['regularMarketPreviousClose']:.2f}" + FONT + "\n"
+    # After-hours data (available after market closes)
+    post_change = symbol_data.get('postMarketChange')
+    post_change_pct = symbol_data.get('postMarketChangePercent')
+    if post_change is not None and post_change_pct is not None:
+        post_sign = '+' if post_change >= 0 else ''
+        post_fmt = f"{post_sign}{post_change_pct:.2%} ({post_sign}{post_change:.2f})"
+        output += f"--After-hours:    {post_fmt}" + FONT + "\n"
+    # Pre-market data (available before market opens)
+    pre_change = symbol_data.get('preMarketChange')
+    pre_change_pct = symbol_data.get('preMarketChangePercent')
+    if pre_change is not None and pre_change_pct is not None:
+        pre_sign = '+' if pre_change >= 0 else ''
+        output += f"--Pre-market:     {pre_sign}{pre_change_pct:.2%} ({pre_sign}{pre_change:.2f})" \
+               + FONT + "\n"
     output += f"--Open:           {symbol_data['regularMarketOpen']:.2f}" + FONT + "\n"
     output += f"--Day's Range:    {symbol_data['regularMarketDayLow']:.2f}" \
            + f" - {symbol_data['regularMarketDayHigh']:.2f}" + FONT + "\n"
+
     return output
+
 
 def main():
     """ Main function """


### PR DESCRIPTION
Display extended hours trading data when available:
- After-hours change percentage and value (shown after market close)
- Pre-market change percentage and value (shown before market open)